### PR TITLE
don't use pip

### DIFF
--- a/day2/ooi_data_access/environment.yml
+++ b/day2/ooi_data_access/environment.yml
@@ -14,5 +14,4 @@ dependencies:
   - cmocean
   - obspy
   - av
-  - pip:
-    - pycamhd
+  - pycamhd


### PR DESCRIPTION
It is usually OK to install `pip` packages like that but sometimes they pull `numpy` and it can be troublesome. To avoid that I just packages `pycamhd` on `conda-forge` and we can drop that.